### PR TITLE
retirado ID da lista, porque é apenas uma contagem

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -13,7 +13,7 @@
                     @foreach ($atendimentos as $atendimento)
                         <div class="mb-4">
                             <!--<h2 class="text-lg font-semibold">(ID:{{ $atendimento->id }})</h2>-->
-                            <h2 class="text-lg font-semibold">(ID:{{ $loop->iteration }})</h2>
+                            <h2 class="text-lg font-semibold">(--:{{ $loop->iteration }}:--)</h2>
                             <p class="text-gray-800">{{ $atendimento->status }}</p>
                             <p class="text-sm text-gray-500">Criado em: {{ $atendimento->created_at }}</p>
                             <p class="text-sm text-gray-500">Atualizado em: {{ $atendimento->updated_at }}</p>


### PR DESCRIPTION
Apenas para a lista ficar sem correlação com o ID do banco de registro. Ficando apenas ordenação dos chamados listados.